### PR TITLE
Add system-wide runner discovery (XDG_DATA_DIRS + /usr/share)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ The RPMs are the packaged builds under `dist/`, produced by [Packaging](#packagi
 Public package:
 
 ```bash
-sudo dnf install ./dist/dlssnr-0.2.5-4.fc44.x86_64.rpm
+sudo dnf install ./dist/dlssnr-0.2.5-5.fc44.x86_64.rpm
 ```
 
 Personal package:
 
 ```bash
-sudo dnf install ./dist/dlssnr-personal-0.2.5-4.fc44.x86_64.rpm
+sudo dnf install ./dist/dlssnr-personal-0.2.5-5.fc44.x86_64.rpm
 ```
 
 `wine` is a recommended package, not a hard dependency, so Proton-only users are not forced to install host Wine.
@@ -99,10 +99,10 @@ prefix survive the update:
 
 ```bash
 dlssnr-helper stop
-sudo dnf upgrade ./dist/dlssnr-0.2.5-4.fc44.x86_64.rpm
+sudo dnf upgrade ./dist/dlssnr-0.2.5-5.fc44.x86_64.rpm
 ```
 
-(`rpm -Uvh ./dist/dlssnr-0.2.5-4.fc44.x86_64.rpm` does the same job on systems without `dnf`.)
+(`rpm -Uvh ./dist/dlssnr-0.2.5-5.fc44.x86_64.rpm` does the same job on systems without `dnf`.)
 Relaunch any game that was presenting through the layer so it picks up the new layer library.
 
 The two variants carry the same files and conflict with each other, so switching between them is a
@@ -123,8 +123,8 @@ older tarballs die at exec on Arch-based systems with
 Extract the tarball:
 
 ```bash
-tar -xzf dist/dlssnr-0.2.5-4-linux-x86_64.tar.gz
-cd dlssnr-0.2.5-4-linux-x86_64
+tar -xzf dist/dlssnr-0.2.5-5-linux-x86_64.tar.gz
+cd dlssnr-0.2.5-5-linux-x86_64
 ```
 
 User install, no root required:
@@ -152,8 +152,8 @@ over the old one -- user config, state and the managed prefix are not touched:
 
 ```bash
 dlssnr-helper stop
-tar -xzf dist/dlssnr-0.2.5-4-linux-x86_64.tar.gz
-cd dlssnr-0.2.5-4-linux-x86_64
+tar -xzf dist/dlssnr-0.2.5-5-linux-x86_64.tar.gz
+cd dlssnr-0.2.5-5-linux-x86_64
 ./install.sh --user        # or: sudo ./install.sh --system
 ```
 
@@ -255,7 +255,13 @@ Custom compatibility tools are discovered from:
 $XDG_DATA_HOME/Steam/compatibilitytools.d
 ~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d
 ~/snap/steam/common/.local/share/Steam/compatibilitytools.d
+$XDG_DATA_DIRS/steam/compatibilitytools.d (each entry, plus /usr/local/share and /usr/share always)
 ```
+
+System-wide tools (CachyOS ships Proton-CachyOS under `/usr/share/steam/compatibilitytools.d`) are
+discovered from every directory in `$XDG_DATA_DIRS` and, because Steam Runtime rewrites that
+variable inside its container, from the XDG defaults `/usr/local/share` and `/usr/share` regardless.
+User directories are scanned first, so a user-installed tool wins ties against a system copy.
 
 List discovered runners:
 

--- a/common/runner_discovery.cpp
+++ b/common/runner_discovery.cpp
@@ -120,7 +120,24 @@ std::vector<RunnerInfo> discoverCustomRunners() {
     scanCompatibilityTools(fs::path(home) / ".var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d", runners);
     scanCompatibilityTools(fs::path(home) / "snap/steam/common/.local/share/Steam/compatibilitytools.d", runners);
 
-    std::sort(runners.begin(), runners.end(), [](const RunnerInfo& a, const RunnerInfo& b) {
+    // System-wide data dirs, scanned after the user dirs so user installs win score ties.
+    // The XDG defaults are always included, not just used as a fallback: Steam Runtime scrubs
+    // XDG_DATA_DIRS and points it at container paths, so trusting the variable alone would
+    // miss /usr/share/steam/compatibilitytools.d (CachyOS) when launched from %command%.
+    std::vector<std::string> dataDirs{"/usr/local/share", "/usr/share"};
+    if (const char* env = std::getenv("XDG_DATA_DIRS")) {
+        std::stringstream ss(env);
+        std::string dir;
+        while (std::getline(ss, dir, ':')) {
+            if (dir.empty() || dir[0] != '/') continue;
+            dataDirs.push_back(dir);
+        }
+    }
+    for (const auto& dir : dataDirs) {
+        scanCompatibilityTools(fs::path(dir) / "steam" / "compatibilitytools.d", runners);
+    }
+
+    std::stable_sort(runners.begin(), runners.end(), [](const RunnerInfo& a, const RunnerInfo& b) {
         if (a.score != b.score) return a.score > b.score;
         return a.name < b.name;
     });

--- a/dlssnr-helper
+++ b/dlssnr-helper
@@ -284,10 +284,28 @@ detect_proton() {
     fi
   fi
 
-  for base in \
-    "${XDG_DATA_HOME:-$HOME/.local/share}/Steam/compatibilitytools.d" \
-    "$HOME/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d" \
-    "$HOME/snap/steam/common/.local/share/Steam/compatibilitytools.d"; do
+  # System-wide data dirs come last so user installs win score ties. The XDG defaults are
+  # always scanned, not just used as a fallback: Steam Runtime scrubs XDG_DATA_DIRS and points
+  # it at container paths, so trusting the variable alone would miss
+  # /usr/share/steam/compatibilitytools.d (CachyOS) when launched from %command%.
+  local bases="${XDG_DATA_HOME:-$HOME/.local/share}/Steam/compatibilitytools.d
+$HOME/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d
+$HOME/snap/steam/common/.local/share/Steam/compatibilitytools.d
+/usr/local/share/steam/compatibilitytools.d
+/usr/share/steam/compatibilitytools.d"
+  local entry oldifs="$IFS"
+  IFS=':'
+  set -f
+  for entry in ${XDG_DATA_DIRS:-}; do
+    [ -n "$entry" ] || continue
+    [ "${entry#/}" != "$entry" ] || continue
+    bases="$bases
+$entry/steam/compatibilitytools.d"
+  done
+  set +f
+  IFS="$oldifs"
+
+  while IFS= read -r base; do
     [ -d "$base" ] || continue
     for dir in "$base"/*; do
       [ -x "$dir/proton" ] || continue
@@ -302,7 +320,9 @@ detect_proton() {
         best_score="$score"
       fi
     done
-  done
+  done <<EOF
+$bases
+EOF
   printf '%s' "$best"
 }
 
@@ -325,8 +345,9 @@ detect_wine() {
 detect_steam_root() {
   local d
   for d in \
-    "$HOME/.local/share/Steam" \
+    "${XDG_DATA_HOME:-$HOME/.local/share}/Steam" \
     "$HOME/.steam/steam" \
+    "$HOME/.steam/root" \
     "$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam"; do
     if [ -d "$d" ]; then
       printf '%s' "$d"

--- a/packaging/dlssnr-personal.spec
+++ b/packaging/dlssnr-personal.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 %global _enable_debug_packages 0
 %global _include_debuginfo_sources 0
-%global pkg_release 4
+%global pkg_release 5
 
 Name:           dlssnr-personal
 Version:        0.2.5
@@ -80,6 +80,16 @@ fi
 /sbin/ldconfig || :
 
 %changelog
+* Tue Sep 08 2026 DLSS5VKLayer - 0.2.5-5
+- Runner discovery: system-wide compatibility tools are now found. On top of the per-user dirs, every
+  directory in $XDG_DATA_DIRS and the XDG defaults /usr/local/share and /usr/share are scanned -- the
+  defaults always, not merely as a fallback, because Steam Runtime rewrites XDG_DATA_DIRS inside its
+  container. This is where CachyOS ships Proton-CachyOS (/usr/share/steam/compatibilitytools.d), and
+  the XDG_DATA_DIRS scan covers other distro layouts (NixOS, custom prefixes) without further edits.
+  User dirs are scanned first and the sort is stable, so a user-installed tool wins a name/score tie
+  against a system copy. runner_probe and the dlssnr-helper shell fallback were updated in lockstep.
+- Helper: detect_steam_root now honours $XDG_DATA_HOME and also checks ~/.steam/root.
+
 * Tue Sep 08 2026 DLSS5VKLayer - 0.2.5-4
 - Helper: the nvapi64.dll load is now exception-guarded and skipped when the runner already supplies
   NVAPI (the launcher sets DLSSNR_SKIP_NVAPI for Proton, where DXVK-NVAPI answers NVAPI). Forcing the

--- a/packaging/dlssnr.spec
+++ b/packaging/dlssnr.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 %global _enable_debug_packages 0
 %global _include_debuginfo_sources 0
-%global pkg_release 4
+%global pkg_release 5
 
 Name:           dlssnr
 Version:        0.2.5
@@ -76,6 +76,16 @@ fi
 /sbin/ldconfig || :
 
 %changelog
+* Tue Sep 08 2026 DLSS5VKLayer - 0.2.5-5
+- Runner discovery: system-wide compatibility tools are now found. On top of the per-user dirs, every
+  directory in $XDG_DATA_DIRS and the XDG defaults /usr/local/share and /usr/share are scanned -- the
+  defaults always, not merely as a fallback, because Steam Runtime rewrites XDG_DATA_DIRS inside its
+  container. This is where CachyOS ships Proton-CachyOS (/usr/share/steam/compatibilitytools.d), and
+  the XDG_DATA_DIRS scan covers other distro layouts (NixOS, custom prefixes) without further edits.
+  User dirs are scanned first and the sort is stable, so a user-installed tool wins a name/score tie
+  against a system copy. runner_probe and the dlssnr-helper shell fallback were updated in lockstep.
+- Helper: detect_steam_root now honours $XDG_DATA_HOME and also checks ~/.steam/root.
+
 * Tue Sep 08 2026 DLSS5VKLayer - 0.2.5-4
 - Helper: the nvapi64.dll load is now exception-guarded and skipped when the runner already supplies
   NVAPI (the launcher sets DLSSNR_SKIP_NVAPI for Proton, where DXVK-NVAPI answers NVAPI). Forcing the


### PR DESCRIPTION
## Summary

Fixes #3. Runner discovery now scans every `$XDG_DATA_DIRS` entry plus `/usr/local/share` and `/usr/share` (always, not just as a fallback, since Steam Runtime rewrites the variable inside its container) for `steam/compatibilitytools.d`. This covers CachyOS (`/usr/share/steam/compatibilitytools.d`) and other distro layouts without further edits.

- User dirs are scanned first with a stable sort, so user installs win name/score ties against system copies.
- `runner_probe` and the `dlssnr-helper` shell fallback updated in lockstep; relative and glob-like `XDG_DATA_DIRS` entries are skipped safely.
- Bonus: `detect_steam_root()` now honors `$XDG_DATA_HOME` and checks `~/.steam/root`.

## Verification

- Fabricated CachyOS-style dirs (`<dir>/steam/compatibilitytools.d/Proton-CachyOS .../proton`) are found by both `runner_probe` and the shell fallback.
- Valve official tools stay excluded; duplicate and relative `XDG_DATA_DIRS` entries are handled.
- `strace` confirms `/usr/share/steam/compatibilitytools.d` is stat'd even with a scrubbed `XDG_DATA_DIRS` (Pressure Vessel scenario).
- Packaged payload verified from the built tarball.

Fixes #3