### PR TITLE
fix: refuse frames below a 64x64 floor (1x1 probe swapchain hangs the GPU)

### DIFF
--- a/common/shm_protocol.h
+++ b/common/shm_protocol.h
@@ -44,6 +44,11 @@ static constexpr uint32_t kShmVersion = 10;
 
 
 static constexpr uint32_t kMaxW = 7680, kMaxH = 4320;
+// And a floor. A game that presents a 1x1 probe swapchain -- NWN:EE does, behind its real window --
+// used to have the model built at that size, and the first submit hung the GPU channel outright
+// (Xid 109, CTX SWITCH TIMEOUT), taking the game down with it. 300x300 is known good; nothing below
+// this is a frame worth composing anyway.
+static constexpr uint32_t kMinW = 64, kMinH = 64;
 // Eight bytes a pixel: the float16 proxy needs them, and the 8-bit path simply uses the first half of
 // each region. The mapping is file-backed and sparse, so an SDR session never commits the second half.
 static constexpr size_t kMaxFrame = size_t(kMaxW) * kMaxH * 8;

--- a/core/ngx_snippet.cpp
+++ b/core/ngx_snippet.cpp
@@ -525,6 +525,13 @@ static void ApplyHdrContract(NgxSnippet& s) {
 bool NgxCreatePass(NgxSnippet& s, uint32_t pass, uint32_t width, uint32_t height,
                    VkCommandBuffer recordingCmd) {
     if (s.disabled || !s.params || pass >= kMaxPasses) return false;
+    // The layer already refuses to send these, but this is the process that touches the GPU, so it
+    // is the one that has to be safe against any client: at 1x1 the model builds happily and the
+    // first submit hangs the channel (Xid 109), which kills the game as well as this helper.
+    if (width < kMinW || height < kMinH) {
+        Log("[ngx] refusing feature at %ux%u: below the %ux%u floor", width, height, kMinW, kMinH);
+        return false;
+    }
     if (s.features[pass]) return true;
 
     ApplyHdrContract(s);

--- a/layer_linux/src/layer.cpp
+++ b/layer_linux/src/layer.cpp
@@ -336,7 +336,7 @@ static bool ShmProcessFrame(ShmMap& s, uint32_t w, uint32_t h, size_t bytes, con
                           void* modelOut, bool proxyInRegion, bool answerFromFd, bool hdrEncode) {
     if (s.dead) return false;
     if (!ShmOpen(s)) { s.dead = true; return false; }
-    if (w > kMaxW || h > kMaxH) return false;
+    if (w > kMaxW || h > kMaxH || w < kMinW || h < kMinH) return false;
     if (bytes != size_t(w) * h * 4 && bytes != size_t(w) * h * 8) return false;
     if (s.hdr->quit.load()) { s.dead = true; return false; }
 
@@ -932,13 +932,15 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_CreateSwapchainKHR(
     sc.hdrKind = DetectHdrKind(sc.format, pCreateInfo->imageColorSpace);
     sc.width = pCreateInfo->imageExtent.width;
     sc.height = pCreateInfo->imageExtent.height;
-    sc.passThrough = !SupportedFormat(sc.format) || sc.width > kMaxW || sc.height > kMaxH;
+    const bool tooSmall = sc.width < kMinW || sc.height < kMinH;
+    sc.passThrough = !SupportedFormat(sc.format) || sc.width > kMaxW || sc.height > kMaxH || tooSmall;
 
     std::lock_guard<std::mutex> lk(dc->lock);
     Log("[layer] swapchain %p %ux%u fmt=%d hdr=%u passThrough=%d%s", (void*)*pSwapchain,
         pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height,
         (int)pCreateInfo->imageFormat, sc.hdrKind, (int)sc.passThrough,
-        sc.passThrough ? (SupportedFormat(sc.format) ? " (too large)" : " (unsupported format)") : "");
+        sc.passThrough ? (!SupportedFormat(sc.format) ? " (unsupported format)"
+                          : tooSmall ? " (too small)" : " (too large)") : "");
     dc->swapchains[*pSwapchain] = std::move(sc);
     return VK_SUCCESS;
 }


### PR DESCRIPTION
## What happens

A game that presents a **1x1 probe swapchain** behind its real window gets the model built at that
size, and the first GPU submit hangs the channel outright. The channel reset takes the game down
with the helper, and every frame afterwards fails with `VK_ERROR_DEVICE_LOST` until the helper is
restarted -- from the outside it just looks like the helper went inactive and the game died.

Neverwinter Nights: Enhanced Edition does this. Launched from Steam with:

```text
VKLayer_DLSS5=1 DLSSNR_SHM=/home/mmxgn/.local/share/dlssnr/run/shm.bin PRESSURE_VESSEL_FILESYSTEMS_RW=/home/mmxgn/.local/share/dlssnr/run PRESSURE_VESSEL_FILESYSTEMS_RO=/nix/store MESA_LOADER_DRIVER_OVERRIDE=zink WINEDLLOVERRIDES="d3dcompiler_47=n;opengl32=n,b" %command%
```

(`DLSSNR_SHM` is off the default path because Steam's container keeps `/tmp` private on this setup,
so the layer and the helper have to meet under `$HOME` instead; not related to this fix.)

The game came up, the helper went active, and then both stopped:

```text
[ngx] VULKAN_CreateFeature(18) pass 0 -> 0x1 seh=0 handle=000000000BB41790 size=1x1 in 231 ms
[ngx] STATUS: Feature=18 created=true path=vulkan-snippet size=1x1
[helper] neural ready 1x1
[helper] frame 48579 failed (w=1 h=1)
[vk] queue submit failed: -4
[helper] frame 48580 failed (w=1 h=1)
```

with the kernel recording a GPU fault attributed to the helper:

```text
NVRM: Xid (PCI:0000:2b:00): 109, pid=186600, name=dlssnr_helper.e, channel 0x00000022,
      errorString CTX SWITCH TIMEOUT, Info 0x1c028
```

Once that has happened, `CreateFeature` in that helper returns `0xbad00002`
(`NVSDK_NGX_Result_FAIL_PlatformError`) for every subsequent size, so the GUI reports "the model
would not initialise" and only a helper restart clears it.

## The fix

There is a ceiling (`kMaxW`/`kMaxH`) but no floor, so a degenerate extent reaches the model
untouched. This adds `kMinW`/`kMinH` = 64 and checks it in the two places that matter:

- `layer_linux/src/layer.cpp` -- the swapchain is marked `passThrough` (logged as `(too small)`) and
  `ShmProcessFrame` refuses the same range, so these frames are never sent.
- `core/ngx_snippet.cpp` -- `NgxCreatePass` refuses to build a feature below the floor. The layer
  already stops sending, but the helper is the process that touches the GPU, so it should be safe
  against any client, including an older or third-party layer on the other end of the mapping.

64 is a judgement call: 1x1 is proven fatal here and 300x300 proven fine, with nothing tested in
between. Below 64x64 there is no plausible frame worth composing, so it seemed the safe place to
draw the line -- happy to move it.

## Verification

With the patch, on the same system:

```text
[layer] swapchain 0x... 32x32 fmt=37 hdr=0 passThrough=1 (too small)
```

and the helper logs nothing at all for that client -- no `CreateFeature`, no submit, so no way to
reach the fault. Still working normally afterwards: 300x300 and 500x500 clients compose as before,
and Baldur's Gate 3 at 2560x1440 (HDR10) is unaffected, `model_up=1` with frames flowing.

## Environment

| | |
|---|---|
| OS | NixOS 26.05.20260910.84d0570 (Yarara), kernel 7.2.4 |
| GPU | NVIDIA GeForce RTX 4090 |
| Driver | 610.57.04 (open kernel module) |
| Runner | GE-Proton11-6-x86_64 via Steam Linux Runtime / pressure-vessel |
| Vulkan loader | 1.4.341.0 |
| Mesa | 24.2.6 (zink, for the OpenGL-on-Vulkan path above) |
| Session | GNOME on Wayland |
| Model DLL | `nvngx_dlssnr.dll` 310.8.0.0 (the RTX 40/50 community build) |

## Not addressed here

Separately, the same session logged eight `NVRM: dmaAllocMapping_GM107: can't update VA space for
mapping @vaddr=0x...` warnings before the first hang, and a second Xid 109 occurred at a normal
raster which `DLSSNR_DMABUF=0` avoids. That looks like the dma-buf import path rather than the
extent, so it is left out of this change; I can open a separate issue with the details if useful.

## Screenshot of NWN:EE finally working with DLSS5 on linux :D

<img width="2558" height="1438" alt="Screenshot From 2026-09-11 21-50-31" src="https://github.com/user-attachments/assets/be279e7a-341e-424f-8f5f-d901fafa6d81" />
