### PR TITLE
hotkey: remember which devices are not keyboards

### DIFF
--- a/layer_linux/src/hotkey.cpp
+++ b/layer_linux/src/hotkey.cpp
@@ -14,7 +14,11 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <fcntl.h>
+#include <iterator>
+#include <set>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 namespace dlssnr {
@@ -127,7 +131,9 @@ bool Hotkeys::OpenEvdev() {
 }
 
 // Opens any keyboard not already open, and drops any that has gone away. Cheap: a readdir of
-// /dev/input and an ioctl per new device, a few times a second at most.
+// /dev/input, and an ioctl only for a device nobody has looked at yet. Devices that turn out not to
+// be keyboards are remembered as such -- see _notKeyboard -- because opening and closing them again
+// every second is not cheap at all.
 void Hotkeys::RescanEvdev() {
     // Devices that have gone away, asked with an ioctl rather than a read.
     //
@@ -150,16 +156,35 @@ void Hotkeys::RescanEvdev() {
     DIR* dir = opendir("/dev/input");
     if (!dir) return;
 
+    // Names seen this pass, so rejections for nodes that have since disappeared can be forgotten
+    // rather than accumulating for the life of the process.
+    std::set<std::string> seen;
+
     while (dirent* e = readdir(dir)) {
         if (std::strncmp(e->d_name, "event", 5) != 0) continue;
         const std::string name = e->d_name;
+        seen.insert(name);
         if (_known.count(name)) continue;
 
         const std::string path = "/dev/input/" + name;
+
+        // Already judged not to be a keyboard? Only trust that verdict if it is still the same
+        // node: a stat is two orders of magnitude cheaper than the open/ioctl/close it replaces.
+        struct stat st{};
+        const bool statOk = ::stat(path.c_str(), &st) == 0;
+        if (statOk) {
+            const auto it = _notKeyboard.find(name);
+            if (it != _notKeyboard.end()) {
+                if (it->second == st.st_ino) continue;
+                _notKeyboard.erase(it);  // same path, different device -- look again
+            }
+        }
+
         const int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
         if (fd < 0) continue;
         if (!LooksLikeAKeyboard(fd)) {
             close(fd);
+            if (statOk) _notKeyboard[name] = st.st_ino;
             continue;
         }
         _fds.push_back(fd);
@@ -168,6 +193,12 @@ void Hotkeys::RescanEvdev() {
         if (_announced) Log("[hotkey] picked up a keyboard that appeared later: %s", path.c_str());
     }
     closedir(dir);
+
+    // Forget rejections for nodes that are gone, so the set tracks /dev/input rather than growing
+    // without bound on a machine that plugs and unplugs a lot.
+    for (auto it = _notKeyboard.begin(); it != _notKeyboard.end();)
+        it = seen.count(it->first) ? std::next(it) : _notKeyboard.erase(it);
+
     _announced = true;
 }
 

--- a/layer_linux/src/hotkey.h
+++ b/layer_linux/src/hotkey.h
@@ -26,8 +26,10 @@
 // increasingly not what people run.
 #include <chrono>
 #include <cstdint>
+#include <map>
 #include <set>
 #include <string>
+#include <sys/types.h>
 #include <vector>
 
 namespace dlssnr {
@@ -66,6 +68,17 @@ class Hotkeys {
     // Which device files are already open, so a rescan is cheap and does not double-open.
     std::set<std::string> _known;
     std::vector<std::string> _knownOrder;
+
+    // Which device files were looked at and turned out not to be keyboards. Remembering the
+    // rejections is what makes a rescan cheap: without this every mouse, audio jack and lid switch
+    // is re-opened and re-closed every second, and closing an evdev node is not free -- measured at
+    // 4-16 ms each on a machine with 24 of them, all of it on the present thread.
+    //
+    // Keyed by inode, not just by name. devtmpfs hands out a fresh inode when a node is destroyed
+    // and recreated, so an unplug/replug that reuses "event6" still looks new here and is probed
+    // again. Name alone would cache the verdict for whatever device lands on that path next, which
+    // is the same class of bug the EVIOCGVERSION check above exists to avoid.
+    std::map<std::string, ino_t> _notKeyboard;
 
     // A keyboard plugged in mid-game has to be picked up, but a readdir every present would be silly.
     // Once a second is far below what anyone would notice and does not vary with frame rate.

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -95,7 +95,9 @@ else
   ENV_DIR="${PREFIX:+$PREFIX}/etc/environment.d"
 fi
 mkdir -p "$ENV_DIR"
-printf 'VK_INSTANCE_LAYERS="VK_LAYER_NV_dlssnr:VK_LAYER_NV_present"\n' > "$ENV_DIR/dlssnr.conf"
+if [ ! -e "$ENV_DIR/dlssnr.conf" ]; then
+  printf 'VK_INSTANCE_LAYERS="VK_LAYER_NV_dlssnr:VK_LAYER_NV_present"\n' > "$ENV_DIR/dlssnr.conf"
+fi
 
 chmod 755 "$BINDIR/dlssnr-helper" "$BINDIR/dlssnr-gui" "$LIBDIR/bin/runner_probe" "$LIBDIR/bin/dlssnr-shmctl" 2>/dev/null || true
 chmod 755 "$LIBDIR/layer/libVkLayer_NV_dlssnr.so" "$LIBDIR/layer32/libVkLayer_NV_dlssnr.so" 2>/dev/null || true


### PR DESCRIPTION
Fixes #12.

## The bug

`RescanEvdev()` records a device in `_known` only when it passes `LooksLikeAKeyboard()`. Devices that fail are closed and forgotten, so they are opened, probed and closed again on the next scan — once a second, for the life of the process, on the present thread.

```cpp
if (_known.count(name)) continue;          // only keyboards are ever in _known
const int fd = open(path.c_str(), ...);
if (!LooksLikeAKeyboard(fd)) {
    close(fd);                              // rejected -> not remembered
    continue;                               // so it is re-opened next scan, forever
}
```

The header comment describes the intent exactly — *"a readdir of /dev/input and an ioctl per new device"* — the missing negative cache is what makes it untrue in practice.

## Why it is expensive

`close()` on an evdev node is not free. Measured per device on this machine:

```
device                  open ms  close ms  name
/dev/input/event10        0.004    15.942  PC Speaker
/dev/input/event14        0.003    15.957  HDA NVidia HDMI/DP,pcm=7
/dev/input/event19        0.003    11.965  HD-Audio Generic Line
/dev/input/event9         0.002    11.943  GameSir-Cyclone 2
/dev/input/event6         0.002     8.376  Logitech USB Receiver
...  18 of 24 nodes are slow; mostly HDA audio-jack nodes
────────────────────────────────────────────────────────────
TOTAL full rescan                124.8 ms
```

`open` and `ioctl` are ~3 µs; the cost is entirely in `close()`. With 23 non-keyboard nodes that is ~125 ms of present-thread stall, once per second, in any application running with `VKLayer_DLSS5=1` — with or without neural rendering enabled, since the hotkey watcher runs regardless.

Under `strace -f` one TID accounts for 116,406 of 116,422 syscalls (the render/present thread) and the whole rescan sits inline in its syscall stream.

Machines with fewer input nodes will see proportionally less; anyone with a lot of HDA audio jacks will see this.

## The change

Remember the rejections as well, so each node is probed once instead of once per second.

The verdict is keyed by **inode**, not by name. devtmpfs issues a fresh inode when a node is destroyed and recreated, so an unplug/replug that reuses `event6` is probed again rather than inheriting the previous device's verdict. This is deliberately the same concern the existing `EVIOCGVERSION` liveness check documents — a stale verdict attached to a recycled path is how the key silently stops working.

Rejections for nodes that have disappeared are dropped at the end of each pass, so the set tracks `/dev/input` rather than growing for the life of the process.

Steady-state scans now do a `readdir` plus a `stat` per known-uninteresting node, and no `open`/`ioctl`/`close` at all.

## Results

`vkcube --c 1200`, median of 5 runs:

| configuration | time | vs no layer |
|---|---|---|
| no layer | 5.17s | — |
| evdev, before | 6.52s | +26.1% |
| evdev, after | 5.67s | **+9.7%** |
| x11 backend (control) | 5.37s | +3.9% |

Event-node opens over a 16s run: **392 → 24**, i.e. 23.1 per scan → 1.4.

## Testing

- **Open counts** — `strace` confirms one probe pass instead of one per second.
- **Frame time** — table above; the evdev penalty drops to near the x11 backend, which performs no device enumeration at all.
- **Hotplug still works** — with a uinput virtual keyboard created *after* the process starts, the layer logs `picked up a keyboard that appeared later: /dev/input/event24` and the toggle key then works on it. This is the behaviour the rescan exists for and it is unchanged.
- **Replug regression** — a standalone test of the caching rules covers a node being replaced by a different device on the same path (must re-probe), a repeat scan with nothing changed (must not re-probe), and nodes disappearing (rejection set must shrink). Happy to include it as a proper test target if you would like it in-tree; it needs a fake directory since it cannot drive real `/dev/input`.
- **End-to-end hotkey** — synthetic F10 presses through the virtual keyboard toggle neural rendering on and off as expected.

Built clean with `meson setup build && ninja -C build`; no new warnings.

---

Note: I opened #13 about the GPU-utilization ceiling and have since closed it — on measurement that one is mostly the NGX inference itself rather than a defect, and my analysis there was wrong twice over. This PR is unrelated to it and stands on its own.
